### PR TITLE
Fix package versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "real-life-quests",
       "version": "1.0.0",
       "dependencies": {
-        "@expo/webpack-config": "^19.0.0",
+        "@expo/webpack-config": "^23.0.0",
         "@firebase/auth": "^1.10.0",
         "@react-navigation/native": "^7.1.6",
         "@react-navigation/native-stack": "^7.3.10",
@@ -16,8 +16,8 @@
         "expo-auth-session": "~6.0.3",
         "expo-web-browser": "~14.0.2",
         "firebase": "^10.7.0",
-        "react": "18.3.1",
-        "react-dom": "18.3.1",
+        "react": "18.2.0",
+        "react-dom": "18.2.0",
         "react-native": "0.76.9",
         "react-native-safe-area-context": "4.12.0",
         "react-native-screens": "~4.4.0",
@@ -2273,9 +2273,9 @@
       }
     },
     "node_modules/@expo/webpack-config": {
-      "version": "19.0.1",
-      "resolved": "https://registry.npmjs.org/@expo/webpack-config/-/webpack-config-19.0.1.tgz",
-      "integrity": "sha512-5bSxXTUd/DCF44+1dSyU23YKLOOYCr9pMJ+C5Vw7PAi6v6OEyNp4uOVMk2x5DAEpXtvOsJCxvNZdmtY/IqmO/A==",
+      "version": "23.0.0",
+      "resolved": "https://registry.npmjs.org/@expo/webpack-config/-/webpack-config-23.0.0.tgz",
+      "integrity": "",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.20.2",
@@ -12599,8 +12599,8 @@
       }
     },
     "node_modules/react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
       "dependencies": {
@@ -12642,8 +12642,8 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
       "dependencies": {
@@ -12651,7 +12651,7 @@
         "scheduler": "^0.23.2"
       },
       "peerDependencies": {
-        "react": "^18.3.1"
+        "react": "^18.2.0"
       }
     },
     "node_modules/react-freeze": {
@@ -12667,8 +12667,8 @@
       }
     },
     "node_modules/react-is": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "web": "expo start --web"
   },
   "dependencies": {
-    "@expo/webpack-config": "^19.0.0",
+    "@expo/webpack-config": "^23.0.0",
     "@firebase/auth": "^1.10.0",
     "@react-navigation/native": "^7.1.6",
     "@react-navigation/native-stack": "^7.3.10",
@@ -17,8 +17,8 @@
     "expo-auth-session": "~6.0.3",
     "expo-web-browser": "~14.0.2",
     "firebase": "^10.7.0",
-    "react": "18.3.1",
-    "react-dom": "18.3.1",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
     "react-native": "0.76.9",
     "react-native-safe-area-context": "4.12.0",
     "react-native-screens": "~4.4.0",


### PR DESCRIPTION
## Summary
- update expo webpack config version
- use stable React 18.2 versions

## Testing
- `npm install --package-lock-only` *(fails: network error)*