### PR TITLE
Add expo-specific run instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,38 @@
+# Real Life Quests
+
+Real Life Quests is a React Native application built with Expo. It helps you turn everyday goals into quests so you can track and complete them in a fun way.
+
+## Getting Started
+
+### Install Dependencies
+
+```bash
+npm install
+```
+
+This installs the Expo CLI locally along with other packages.
+
+### Run the App
+
+Start the Expo development server. You can use the npm script or call Expo
+directly:
+
+```bash
+npm start
+# or
+npx expo start
+```
+
+Expo will launch a browser window where you can choose to run the app on iOS,
+Android or the web. You can also scan the QR code with the Expo Go app on your
+device. For a specific platform, you can run `npm run android`, `npm run ios`,
+or `npm run web`.
+
+### Run Tests
+
+The project uses Jest for testing. Execute the test suite with:
+
+```bash
+npm test
+```
+


### PR DESCRIPTION
## Summary
- clarify that `npm start` runs Expo
- add `npx expo start` option and platform-specific scripts

## Testing
- `npm test --silent` *(fails: jest not found)*