### PR TITLE
Use Metro for web bundling

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -26,7 +26,7 @@ module.exports = {  expo: {
     },
     web: {
       favicon: './assets/favicon.png',
-      bundler: 'webpack',
+      bundler: 'metro',
       output: 'static',
       config: {
         firebase: {

--- a/metro.config.js
+++ b/metro.config.js
@@ -1,0 +1,7 @@
+// Learn more https://docs.expo.dev/guides/customizing-metro
+const { getDefaultConfig } = require('expo/metro-config');
+
+/** @type {import('expo/metro-config').MetroConfig} */
+const config = getDefaultConfig(__dirname);
+
+module.exports = config;


### PR DESCRIPTION
## Summary
- switch Expo web bundler to `metro`
- add a default `metro.config.js`

## Testing
- `npm test`
