### PR TITLE
Fix deploy script with no SSG

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "ios": "expo start --ios",
     "web": "expo start --web",
     "test": "jest",
-    "deploy-hosting": "npx expo export && mv dist public && npx firebase deploy --only hosting"
+    "deploy-hosting": "npx expo export --no-ssg && mv dist public && npx firebase deploy --only hosting"
   },
   "dependencies": {
     "@firebase/auth": "^1.10.0",


### PR DESCRIPTION
## Summary
- restore the `--no-ssg` flag so web export succeeds without Expo Router routes

## Testing
- `npm test`