### PR TITLE
Fix deploy script with metro export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .env
 node_modules/
 .expo/
+dist/

--- a/app.config.js
+++ b/app.config.js
@@ -27,7 +27,7 @@ module.exports = {  expo: {
     web: {
       favicon: './assets/favicon.png',
       bundler: 'metro',
-      output: 'static',
+      output: 'server',
       config: {
         firebase: {
           authDomain: "real-life-quests-27f84.firebaseapp.com"

--- a/app/index.js
+++ b/app/index.js
@@ -1,0 +1,2 @@
+import App from '../App';
+export default App;

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "ios": "expo start --ios",
     "web": "expo start --web",
     "test": "jest",
-    "deploy-hosting": "npx expo export && mv dist public && npx firebase deploy --only hosting"
+    "deploy-hosting": "npx expo export --no-ssg && mv dist public && npx firebase deploy --only hosting"
   },
   "dependencies": {
     "@firebase/auth": "^1.10.0",


### PR DESCRIPTION
## Summary
- add `app/index.js` route so Metro export works
- switch web output to `server` and ignore build folder

## Testing
- `npm test`
