### PR TITLE
Fix Firebase CLI in deploy script

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "ios": "expo start --ios",
     "web": "expo start --web",
     "test": "jest",
-    "deploy-hosting": "npx expo export && mv dist public && npx firebase deploy --only hosting"
+    "deploy-hosting": "npx expo export --no-ssg && mv dist public && npx firebase-tools deploy --only hosting"
   },
   "dependencies": {
     "@firebase/auth": "^1.10.0",


### PR DESCRIPTION
## Summary
- use `firebase-tools` explicitly in deploy script so npx can run the CLI

## Testing
- `npm test`
