### PR TITLE
Fix quest item swipe edit

### DIFF
--- a/components/QuestItem.js
+++ b/components/QuestItem.js
@@ -28,18 +28,18 @@ export default function QuestItem({
   const renderLeftActions = () => (
     <TouchableOpacity
       style={styles.leftAction}
-      onPress={() => setIsEditing(true)}
+      onPress={() => onDelete(item.id)}
     >
-      <Text style={styles.actionText}>Edit</Text>
+      <Text style={styles.actionText}>Delete</Text>
     </TouchableOpacity>
   );
 
   const renderRightActions = () => (
     <TouchableOpacity
       style={styles.rightAction}
-      onPress={() => onDelete(item.id)}
+      onPress={() => setIsEditing(true)}
     >
-      <Text style={styles.actionText}>Delete</Text>
+      <Text style={styles.actionText}>Edit</Text>
     </TouchableOpacity>
   );
 
@@ -77,8 +77,8 @@ export default function QuestItem({
     <Swipeable
       renderLeftActions={renderLeftActions}
       renderRightActions={renderRightActions}
-      onSwipeableLeftOpen={() => setIsEditing(true)}
-      onSwipeableRightOpen={() => onDelete(item.id)}
+      onSwipeableLeftOpen={() => onDelete(item.id)}
+      onSwipeableRightOpen={() => setIsEditing(true)}
     >
       {content}
     </Swipeable>

--- a/components/__tests__/QuestItem.test.js
+++ b/components/__tests__/QuestItem.test.js
@@ -1,12 +1,13 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
+import { act } from 'react-test-renderer';
 import QuestItem from '../QuestItem';
 
 jest.mock('react-native-gesture-handler', () => {
   const React = require('react');
   const { View } = require('react-native');
-  const Swipeable = ({ renderLeftActions, renderRightActions, children }) => (
-    <View>
+  const Swipeable = ({ renderLeftActions, renderRightActions, children, ...rest }) => (
+    <View testID="swipeable" {...rest}>
       {renderLeftActions && renderLeftActions()}
       {children}
       {renderRightActions && renderRightActions()}
@@ -45,5 +46,21 @@ describe('QuestItem', () => {
     const { getByText } = render(<QuestItem {...baseProps} />);
     fireEvent.press(getByText('Quest (+10 XP)'));
     expect(baseProps.onComplete).toHaveBeenCalledWith(1);
+  });
+
+  it('enters edit mode when swiped right', () => {
+    const { getByTestId, getByText } = render(<QuestItem {...baseProps} />);
+    act(() => {
+      getByTestId('swipeable').props.onSwipeableRightOpen();
+    });
+    expect(getByText('Save')).toBeTruthy();
+  });
+
+  it('deletes quest when swiped left', () => {
+    const { getByTestId } = render(<QuestItem {...baseProps} />);
+    act(() => {
+      getByTestId('swipeable').props.onSwipeableLeftOpen();
+    });
+    expect(baseProps.onDelete).toHaveBeenCalledWith(1);
   });
 });


### PR DESCRIPTION
## Summary
- allow editing a quest when swiping right
- move delete action to left swipe
- test swipe behaviors

## Testing
- `npm test`
